### PR TITLE
This fixes "Missing submodule" error in XCode

### DIFF
--- a/AFNetworking/AFNetworking.h
+++ b/AFNetworking/AFNetworking.h
@@ -26,23 +26,23 @@
 #ifndef _AFNETWORKING_
     #define _AFNETWORKING_
 
-    #import "AFURLRequestSerialization.h"
-    #import "AFURLResponseSerialization.h"
-    #import "AFSecurityPolicy.h"
-    #import "AFNetworkReachabilityManager.h"
+    #import <AFNetworking/AFURLRequestSerialization.h>
+    #import <AFNetworking/AFURLResponseSerialization.h>
+    #import <AFNetworking/AFSecurityPolicy.h>
+    #import <AFNetworking/AFNetworkReachabilityManager.h>
 
-    #import "AFURLConnectionOperation.h"
-    #import "AFHTTPRequestOperation.h"
-    #import "AFHTTPRequestOperationManager.h"
+    #import <AFNetworking/AFURLConnectionOperation.h>
+    #import <AFNetworking/AFHTTPRequestOperation.h>
+    #import <AFNetworking/AFHTTPRequestOperationManager.h>
 
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-    #import "UIKit+AFNetworking.h"
+    #import <AFNetworking/UIKit+AFNetworking.h>
 #endif
 
 #if ( ( defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1090) || \
       ( defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000 ) )
-    #import "AFURLSessionManager.h"
-    #import "AFHTTPSessionManager.h"
+    #import <AFNetworking/AFURLSessionManager.h>
+    #import <AFNetworking/AFHTTPSessionManager.h>
 #endif
 
 #endif /* _AFNETWORKING_ */

--- a/UIKit+AFNetworking/UIKit+AFNetworking.h
+++ b/UIKit+AFNetworking/UIKit+AFNetworking.h
@@ -25,14 +25,14 @@
 #ifndef _UIKIT_AFNETWORKING_
     #define _UIKIT_AFNETWORKING_
 
-    #import "AFNetworkActivityIndicatorManager.h"
+    #import <AFNetworking/AFNetworkActivityIndicatorManager.h>
 
-    #import "UIActivityIndicatorView+AFNetworking.h"
-    #import "UIAlertView+AFNetworking.h"
-    #import "UIButton+AFNetworking.h"
-    #import "UIImageView+AFNetworking.h"
-    #import "UIKit+AFNetworking.h"
-    #import "UIProgressView+AFNetworking.h"
-    #import "UIRefreshControl+AFNetworking.h"
-    #import "UIWebView+AFNetworking.h"
+    #import <AFNetworking/UIActivityIndicatorView+AFNetworking.h>
+    #import <AFNetworking/UIAlertView+AFNetworking.h>
+    #import <AFNetworking/UIButton+AFNetworking.h>
+    #import <AFNetworking/UIImageView+AFNetworking.h>
+    #import <AFNetworking/UIKit+AFNetworking.h>
+    #import <AFNetworking/UIProgressView+AFNetworking.h>
+    #import <AFNetworking/UIRefreshControl+AFNetworking.h>
+    #import <AFNetworking/UIWebView+AFNetworking.h>
 #endif /* _UIKIT_AFNETWORKING_ */


### PR DESCRIPTION
When trying to import <AFNetworking/UIImageView+AFNetworking.h> directly for example, XCode would fail with a "Missing submodule" in AFNetworking.

http://cloud.plutinosoft.com/image/1d091X2j2K1V

This fixes the issue.